### PR TITLE
Add changelog.

### DIFF
--- a/exact-pi.cabal
+++ b/exact-pi.cabal
@@ -14,7 +14,8 @@ maintainer:          douglas.mcclean@gmail.com
 -- copyright:           
 category:            Data
 build-type:          Simple
-extra-source-files:  README.md
+extra-source-files:  README.md,
+                     changelog.md
 cabal-version:       >=1.10
 
 library
@@ -29,4 +30,3 @@ library
 source-repository head
   type:                git
   location:            https://github.com/dmcclean/exact-pi.git
-  


### PR DESCRIPTION
A link to this file will show up on Hackage page (currently says “No changelog available”). I haven't tried to fill in the history for you but would suggest updating when releasing new version, to save users from having to rely on [hdiff](http://hdiff.luite.com/cgit/exact-pi/commit).
