### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/exact-pi.cabal
+++ b/exact-pi.cabal
@@ -23,7 +23,7 @@ tested-with:         GHC == 7.8.4,
 library
   exposed-modules:     Data.ExactPi,
                        Data.ExactPi.TypeLevel
-  build-depends:       base >=4.7 && <5,
+  build-depends:       base >=4.11 && <5,
                        numtype-dk >= 0.5
   if impl(ghc <8.0)
     build-depends:
@@ -34,7 +34,7 @@ library
 
 test-suite spec
   main-is:             Test.hs
-  build-depends:       base >=4.7 && <5,
+  build-depends:       base >=4.11 && <5,
                        exact-pi,
                        numtype-dk >= 0.5,
                        QuickCheck >=2.10,

--- a/src/Data/ExactPi.hs
+++ b/src/Data/ExactPi.hs
@@ -197,9 +197,8 @@ approx1 f x = Approximate (f (approximateValue x))
 
 -- | The multiplicative semigroup over 'Rational's augmented with multiples of 'pi'.
 instance Semigroup ExactPi where
-  (<>) = mappend
+  (<>) = (*)
 
 -- | The multiplicative monoid over 'Rational's augmented with multiples of 'pi'.
 instance Monoid ExactPi where
   mempty = 1
-  mappend = (*)


### PR DESCRIPTION
This appeases the -Wnoncanonical-monoid-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/semigroup-monoid